### PR TITLE
Variable name altered in Vercel. Console.log added just for re-deployment

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,6 @@
 // This is your Prisma schema file,
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
+// Obs. Local variable name altered in Vercel for "DATABASE_URL"
 
 generator client {
   provider = "prisma-client-js"


### PR DESCRIPTION
# What this pull request does

Just adds a console.log to the Prisma schema. It's needed to trigger deployment by Vercel.
The change was made in Vercel, adding a DATABASE_URL variable with the same value as POSTGRES_URL, so that it can connect to the Prisma Schema.

