### PR TITLE
Seperate Modal into Popover and Modal

### DIFF
--- a/components/Button/Button.module.css
+++ b/components/Button/Button.module.css
@@ -1,7 +1,6 @@
 .mainContainer {
   border: none;
   min-width: 117px;
-  margin-bottom: 21px;
   padding: 16px 32px;
   border-radius: 10px;
   background-color: #d0d3d9;
@@ -34,6 +33,31 @@
   border: none;
   border-radius: 10px;
   background: #d0d3d9;
+}
+
+.optionButton {
+  font-weight: 500;
+  line-height: 18px;
+  font-size: 16px;
+  color: #333333;
+  background-color: transparent;
+  border: none;
+  min-width: 0px;
+  padding: 0;
+  border-radius: 0px;
+}
+
+.danger {
+  color: #ec7065;
+}
+
+.large {
+  line-height: 22px;
+  font-size: 18px;
+}
+
+.fullWidth {
+  width: 100%;
 }
 
 /* @media screen and (max-width: 500px) {

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -3,28 +3,34 @@ import { ReactNode } from "react";
 import { fontInter } from "../../styles/fonts/index";
 import Link from "next/link";
 
-type Heading1Props = {
-  children: ReactNode;
-  variant?: string;
-  onClick?: () => void;
+export interface ButtonProps extends React.ComponentPropsWithoutRef<"button"> {
+  variant?: string | "optionButton";
+  colorScheme?: "danger";
+  size?: "large";
+  fullWidth?: boolean;
   href?: string;
-};
+}
 
-const Button: React.FC<Heading1Props> = ({
+const Button = ({
   children,
   variant,
   href,
+  size,
+  fullWidth = false,
+  colorScheme,
+  className,
   ...props
-}) => {
+}: ButtonProps) => {
   return (
     <>
-      {" "}
       {href && (
         <Link href={href}>
           <button
             className={`${styles.mainContainer} ${variant && styles[variant]} ${
+              colorScheme && styles[colorScheme]
+            } ${fullWidth && styles.fullWidth} ${size && styles[size]} ${
               fontInter.className
-            }`}
+            } ${className}`}
             {...props}
           >
             {children}
@@ -34,8 +40,10 @@ const Button: React.FC<Heading1Props> = ({
       {!href && (
         <button
           className={`${styles.mainContainer} ${variant && styles[variant]} ${
+            colorScheme && styles[colorScheme]
+          } ${fullWidth && styles.fullWidth} ${size && styles[size]} ${
             fontInter.className
-          }`}
+          } ${className}`}
           {...props}
         >
           {children}

--- a/components/Modal/Modal.module.css
+++ b/components/Modal/Modal.module.css
@@ -3,13 +3,14 @@
   color: black;
   opacity: 0.99;
   position: fixed;
-  margin-top: -20rem;
   text-align: center;
   inset: 0;
   z-index: 30;
   display: flex;
   justify-content: center;
   align-items: center;
+  animation: fadeIn;
+  animation-duration: 0.3s;
 }
 
 .modalContainer {
@@ -17,14 +18,23 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  max-width: 14rem;
+  width: 80%;
+  max-width: 300px;
   border-radius: 8px;
   box-shadow: 0px 12px 24px 0px rgba(126, 129, 139, 0.3);
 
   background-color: white;
 }
 
-@media (min-width: 700px) {
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+/* @media (min-width: 700px) {
   .overlay {
     position: absolute;
     background-color: transparent;
@@ -36,4 +46,4 @@
     position: absolute;
     right: 0;
   }
-}
+} */

--- a/components/PopOver/PopOver.module.css
+++ b/components/PopOver/PopOver.module.css
@@ -1,0 +1,50 @@
+.popoverContainer {
+  position: fixed;
+  z-index: 9;
+  background-color: rgba(0, 0, 0, 0.5);
+  inset: 0;
+}
+
+.popover {
+  position: fixed;
+  bottom: 0;
+  z-index: 10;
+  width: 100vw;
+  background-color: white;
+  left: 0;
+  padding: 50px 24px 50px;
+  border-radius: 10px 10px 0 0;
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  animation-duration: 0.5s;
+  animation-name: slide;
+}
+
+@media screen and (min-width: 768px) {
+  .popoverContainer {
+    background-color: transparent;
+    position: absolute;
+    inset: initial;
+    right: 0px;
+    box-shadow: 0px 12px 24px 0px rgba(126, 129, 139, 0.3);
+    border-radius: 10px;
+  }
+
+  .popover {
+    border-radius: 10px;
+    position: static;
+    min-width: 200px;
+    padding: 24px 20px 34px;
+    width: initial;
+  }
+}
+
+@keyframes slide {
+  from {
+    bottom: -200px;
+  }
+  to {
+    bottom: 0;
+  }
+}

--- a/components/PopOver/PopOver.tsx
+++ b/components/PopOver/PopOver.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useId, useState } from "react";
+import styles from "./PopOver.module.css";
+
+export interface PopOverProps extends React.ComponentPropsWithoutRef<"div"> {
+  show: boolean;
+  close: (e?: React.MouseEvent<HTMLElement>) => void;
+}
+
+export default function Conditional(props: PopOverProps) {
+  if (!props.show) return null;
+
+  return <PopOver {...props} />;
+}
+
+export function usePopOver() {
+  const [show, setShow] = useState(false);
+
+  function open(e: React.MouseEvent<HTMLElement>): void {
+    setShow(true);
+    e.stopPropagation();
+  }
+
+  function close(e: React.MouseEvent<HTMLElement> | undefined): void {
+    setShow(false);
+    e?.stopPropagation();
+  }
+
+  return [show, open, close] as const;
+}
+
+function PopOver({ children, show, close, ...props }: PopOverProps) {
+  const id = useId().replaceAll(":", "");
+
+  useEffect(() => {
+    function detectClickOutside(e: any) {
+      const isClickOutside = e?.target?.closest(`#${id}`) === null;
+
+      if (isClickOutside) {
+        close();
+      }
+    }
+
+    window.addEventListener("click", detectClickOutside);
+
+    return () => {
+      window.removeEventListener("click", detectClickOutside);
+    };
+  }, [id, close]);
+
+  return (
+    <div className={styles.popoverContainer}>
+      <div {...props} className={styles.popover} id={id}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/components/PopOver/index.ts
+++ b/components/PopOver/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PopOver";

--- a/components/card/Card.module.css
+++ b/components/card/Card.module.css
@@ -84,8 +84,6 @@
 
 .deleteCompanyMainContainer {
   padding: 24px 20px;
-  width: 205px;
-  height: 138px;
   display: flex;
   flex-direction: column;
   align-items: left;
@@ -104,6 +102,19 @@
   border: 1px solid #e8eaed;
 }
 
+.closePopOverMobile {
+  position: absolute;
+  right: 24px;
+  top: 24px;
+  background-color: transparent;
+  border: none;
+}
+
+.popOverOption {
+  width: 100%;
+  text-align: start;
+}
+
 .removeButton {
   color: #ec7065;
   display: flex;
@@ -117,6 +128,20 @@
 
 .removeModal {
   margin-top: 24px;
+}
+
+.removeCompanyHeader {
+  font-size: 18px;
+  line-height: 22px;
+  font-weight: 500;
+  margin-bottom: 16px;
+}
+
+.removeCompanySubtitle {
+  font-size: 14px;
+  line-height: 18px;
+  font-weight: 400;
+  margin-bottom: 16px;
 }
 
 .removeMessage {
@@ -136,7 +161,7 @@
 }
 
 .greyLineConfirmation {
-  margin: 10px 0px;
+  margin: 20px 0px;
   width: 100%;
   border: 1px solid #e8eaed;
 }
@@ -190,6 +215,7 @@
 .backButton:hover {
   cursor: pointer;
 }
+
 @media (min-width: 600px) {
   .cardContainer {
     padding: 18px 30px 19px 24px;
@@ -225,7 +251,7 @@
   }
 
   .threeDotsIcon {
-    position: static;
+    position: relative;
     top: auto;
     right: auto;
     margin-bottom: 5px;
@@ -247,6 +273,12 @@
     height: 100%;
     gap: 8px;
     margin-bottom: 0;
+  }
+}
+
+@media screen and (min-width: 768px) {
+  .closePopOverMobile {
+    display: none;
   }
 }
 

--- a/components/card/Card.tsx
+++ b/components/card/Card.tsx
@@ -10,15 +10,13 @@ import { DateTime } from "luxon";
 import { useSession } from "next-auth/react";
 import Avatar from "../avatar/Avatar";
 import { PiDotsThreeOutlineFill } from "react-icons/pi";
-import {
-  AiOutlineLike,
-  AiOutlineDislike,
-  AiTwotoneLike,
-  AiTwotoneDislike,
-  AiOutlineDelete,
-} from "react-icons/ai";
 import { FiEdit3 } from "react-icons/fi";
 import { useRouter } from "next/router";
+import PopOver from "../PopOver";
+import Button from "../Button/Button";
+import BackIcon from "../Atoms/BackIcon/BackIcon";
+import Image from "next/image";
+import { usePopOver } from "../PopOver/PopOver";
 
 type CardProps = {
   id: string;
@@ -53,8 +51,7 @@ const Card: React.FC<CardProps> = ({
   const [error, setError] = useState(false);
   const [successRemoval, setSuccessRemoval] = useState(false);
   const [latestUserEvent, setLatestUserEvent] = useState(userEvent);
-  const [like, setLike] = useState(false);
-  const [dislike, setDislike] = useState(false);
+  const [show, open, close] = usePopOver();
 
   const router = useRouter();
 
@@ -159,37 +156,36 @@ const Card: React.FC<CardProps> = ({
         </div>
       </div>
       <div className={styles.rightBlock}>
-        <div className={styles.threeDotsIcon}>
-          <PiDotsThreeOutlineFill onClick={() => setOpenModal(!openModal)} />
-        </div>
-        <div className={styles.likeDislikeIcons}>
-          {like === false && (
-            <AiOutlineLike
-              onClick={() => {
-                setLike(!like);
-                setDislike(false);
-              }}
-            />
-          )}
-          {like === true && (
-            <AiTwotoneLike
-              onClick={() => {
-                setLike(!like);
-                setDislike(false);
-              }}
-            />
-          )}
-          {dislike === false && (
-            <AiOutlineDislike
-              onClick={() => {
-                setDislike(!dislike);
-                setLike(false);
-              }}
-            />
-          )}
-          {dislike === true && (
-            <AiTwotoneDislike onClick={() => setDislike(!dislike)} />
-          )}
+        <div className={styles.threeDotsIcon} onClick={(e) => open(e)}>
+          <PiDotsThreeOutlineFill />
+          {
+            <PopOver show={show} close={close}>
+              <button className={styles.closePopOverMobile} onClick={close}>
+                <Image
+                  src="assets/close.svg"
+                  height={20}
+                  width={20}
+                  alt="close"
+                />
+              </button>
+              <Button
+                variant="optionButton"
+                onClick={editCompanyHandler}
+                className={styles.popOverOption}
+              >
+                Edit
+              </Button>
+              <div className={styles.greyLineConfirmation}></div>
+              <Button
+                variant="optionButton"
+                colorScheme="danger"
+                onClick={() => setOpenModal(true)}
+                className={styles.popOverOption}
+              >
+                Delete
+              </Button>
+            </PopOver>
+          }
         </div>
         <div className={styles.categoryWrapperContainer}>
           <div className={styles.categoryInnerContainer}>{category}</div>
@@ -197,15 +193,6 @@ const Card: React.FC<CardProps> = ({
 
         <div className={styles.lastVisitContainer}>{displayLastVisit}</div>
       </div>
-      <div className={styles.categoriesContainer}>{category}</div>
-      <button
-        onClick={() => {
-          editCompanyHandler();
-        }}
-      >
-        Edit
-      </button>
-      <button onClick={() => setOpenModal(!openModal)}>Remove</button>
 
       <Modal isOpen={openModal || error} onClose={() => setOpenModal(false)}>
         {!loading && !error && !successRemoval && !selectRemove && (
@@ -214,24 +201,26 @@ const Card: React.FC<CardProps> = ({
             <p className={styles.removeCompanySubtitle}>
               Are you sure you want to remove this company from the list?
             </p>
-            <div className={styles.removeCompanyButtons}>
-              <button
-                className={`${styles.removeButton} ${styles.confirm}`}
-                onClick={() => handleDeleteClick(id)}
-              >
-                Remove
-              </button>
-            </div>
             <div className={styles.greyLineConfirmation}></div>
-            <div
-              className={styles.cancelButton}
+            <Button
+              size="large"
+              variant="optionButton"
+              colorScheme="danger"
+              onClick={() => handleDeleteClick(id)}
+            >
+              Remove
+            </Button>
+            <div className={styles.greyLineConfirmation}></div>
+            <Button
+              size="large"
+              variant="optionButton"
               onClick={() => {
                 setOpenModal(false);
                 setSelectRemove(false);
               }}
             >
               Cancel
-            </div>
+            </Button>
           </div>
         )}
         {loading && !successRemoval && (

--- a/public/assets/close.svg
+++ b/public/assets/close.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 6L6 18" stroke="#A6A0A6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 6L18 18" stroke="#A6A0A6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
# What this pull request does

## What

![Screen Recording 2023-10-05 at 04 12 10 PM](https://github.com/luizfiorentino/fndr/assets/20372832/3786977b-2063-42c8-9235-cc815ba23d92)

Describe or refer to which issue your feature implements

Unified UI changes by @korvenhasta and @luizfiorentino  according to the design of @GulnaraVarshavskaya 

- Simplifying the current Modal on the company card
- Separating out separate Popover component
- Deleted the partially like / dislike feature (for now)

## Why

- The Modal on the homepage was getting complicated
- The Modal and Popover have different behaviours (and styles)
- The like dislike feature is a cool idea, but was partially implemented (no persistence, no design) 

## How

- Made a separate PopOver component
- To open and close it, it uses a `usePopover` hook (this is to detect clicks outside of the popover)

## Steps to test this

- Pull the branch and try the 3 dots button
- Click outside while the popover is open (it should close)

## Anything else

- Dislike / Like feature is a good idea (perhaps we can filter based upon this) We can keep it in mind @luizfiorentino 
- I tried to reuse styles, but it is a bit challenging (we have no margin utils for example).
